### PR TITLE
Update jsass version to gain compile support on 32bit-linux systems

### DIFF
--- a/LibSassGradlePlugin/build.gradle
+++ b/LibSassGradlePlugin/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
 
-	compile ('io.bit3:jsass:5.3.1',
+	compile ('io.bit3:jsass:5.5.0',
 		'org.jruby:jruby:9.1.6.0',
 	)
 	


### PR DESCRIPTION
After jsass added support for 32-bit systems (https://github.com/bit3/jsass/issues/11)
I increased the version of it to 5.5.0