### PR TITLE
Fix default output file type

### DIFF
--- a/LibSassGradlePlugin/src/main/java/com/github/fgiannesini/libsass/gradle/plugin/extension/PluginParametersProvider.java
+++ b/LibSassGradlePlugin/src/main/java/com/github/fgiannesini/libsass/gradle/plugin/extension/PluginParametersProvider.java
@@ -124,7 +124,7 @@ public class PluginParametersProvider {
 
         if (value == null) {
             value = "css" + File.separator
-                    + this.project.getName().toLowerCase() + ".scss";
+                    + this.project.getName().toLowerCase() + ".css";
         }
 
         return this.getResourcePath(value).toUri();


### PR DESCRIPTION
I believe the default output URI was a `.scss` file, while it should be a `.css` file. Please review this tiny edit.